### PR TITLE
Restore wifi country and channel settings

### DIFF
--- a/bin/changewifisettings.py
+++ b/bin/changewifisettings.py
@@ -241,7 +241,6 @@ def fix_wrong_kernel_cmdline():
         )
 
 # Actions.
-
 fix_wrong_kernel_cmdline()
 do_regulatory_country()
 do_channel()
@@ -251,22 +250,15 @@ do_password_protected()
 if password_protected:
     do_password()
 do_ip_address()
-
 # End of actions.
-#
+
+# Restart networking and hostapd service, and wait for completion.
+subprocess.run(['systemctl', 'restart', 'NetworkManager.service'])
+
 # Empty lease file to clean clients list.
 try:
     open(dnsmasq_lease_file, 'w').close()
 except IOError:
     pass
-
-# Empty settings file, for security.
-try:
-    open(settings_file, 'w').close()
-except IOError:
-    pass
-
-# Restart networking and hostapd service.
-subprocess.call(['systemctl', 'restart', 'NetworkManager.service'])
 
 # The end.

--- a/version.php
+++ b/version.php
@@ -26,8 +26,8 @@ defined('MOODLE_INTERNAL') || die;
 
 $plugin = new stdClass();
 
-$plugin->version  = 2026072200;
-$plugin->release = '3.3.0';
+$plugin->version  = 2026080800;
+$plugin->release = '3.3.1';
 $plugin->requires = 2024042200;
 $plugin->supported = [404, 502];
 $plugin->maturity = MATURITY_STABLE;


### PR DESCRIPTION
- We do not delete WiFi settings file. This preserves the file until NetworkManager has finished restarting.
- No security issue, since the WiFi settings file is not web-accessible and anyway we have to - Fixes #174.